### PR TITLE
Fix publishing issue in application

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,8 @@ jobs:
 
       - name: Publish to PyPI (Optional)
         # Only publish to PyPI if PYPI_API_TOKEN secret is set
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && secrets.PYPI_API_TOKEN
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        continue-on-error: true
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
- Secrets cannot be accessed in GitHub Actions if conditions
- Added continue-on-error to handle missing PYPI_API_TOKEN gracefully